### PR TITLE
fix: 修复一个platform在其它传值时，签名不正确的问题，默认参数不受影响

### DIFF
--- a/encrypt/xs_encrypt.py
+++ b/encrypt/xs_encrypt.py
@@ -76,7 +76,7 @@ class XsEncrypt:
         obj = {
             "signSvn": "56",
             "signType": "x2",
-            "appID": platform,
+            "appId": platform,
             "signVersion": "1",
             "payload": await XsEncrypt.base64_to_hex(payload)
         }


### PR DESCRIPTION
在platform为sellercustomer时，XYW_签名会有一位不正确，确认为appId大小写问题。原来的xhs-pc-web不受影响