### PR TITLE
fix(ci): 修复PyPI发布工作流中的smoke test命令…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, dev, refactor/* ]
+    branches: [ master, main, dev, refactor/* ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ master, main, dev ]
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,21 +26,13 @@ jobs:
       # Check that basic features work and we didn't miss to include crucial files
       - name: Smoke test (wheel)
         run: |
-          uv run --isolated --no-project -p 3.12 --with dist/*.whl -c "
-          from xhshow import Xhshow, CryptoProcessor
-          client = Xhshow()
-          print('✅ Wheel package works!')
-          print(f'Xhshow version: {client.__class__.__module__}')
-          "
+          WHEEL_FILE=$(find dist -name "*.whl" -type f)
+          uv run --isolated --no-project -p 3.12 --with "$WHEEL_FILE" -- python -c "from xhshow import Xhshow, CryptoProcessor; client = Xhshow(); print('Wheel package works'); print('Xhshow module:', client.__class__.__module__)"
       
       - name: Smoke test (source distribution)
         run: |
-          uv run --isolated --no-project -p 3.12 --with dist/*.tar.gz -c "
-          from xhshow import Xhshow, CryptoProcessor
-          client = Xhshow()
-          print('✅ Source distribution works!')
-          print(f'Xhshow version: {client.__class__.__module__}')
-          "
+          TARBALL_FILE=$(find dist -name "*.tar.gz" -type f)
+          uv run --isolated --no-project -p 3.12 --with "$TARBALL_FILE" -- python -c "from xhshow import Xhshow, CryptoProcessor; client = Xhshow(); print('Source distribution works'); print('Xhshow module:', client.__class__.__module__)"
       
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always


### PR DESCRIPTION
## Sourcery 摘要

修复 PyPI 发布工作流中的冒烟测试步骤，以正确查找和调用分发文件，并在 CI 触发器中包含“master”分支，用于 push 和 pull requests。

CI:
- 更新发布工作流的冒烟测试，以动态查找 wheel 和 tarball 文件并调整调用命令
- 在 CI 工作流中，将 master 分支添加到 push 和 pull_request 触发器中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix smoke test steps in the PyPI release workflow to correctly locate and invoke distribution files, and include the ‘master’ branch in CI triggers for push and pull requests.

CI:
- Update release workflow smoke tests to dynamically find wheel and tarball files and adjust the invocation command
- Add master branch to push and pull_request triggers in the CI workflow

</details>