### PR TITLE
feat(ci): 添加GitHub Release创建功能…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,58 @@ on:
       - v*
 
 jobs:
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          body: |
+            ## 更新内容
+            
+            ## 安装
+            
+            ```bash
+            pip install xhshow==${{ github.ref_name }}
+            ```
+            
+            ## 使用方法
+            
+            ```python
+            from xhshow import Xhshow
+            
+            client = Xhshow()
+            
+            # GET请求签名
+            signature = client.sign_xs_get(
+                uri="/api/sns/web/v1/user_posted",
+                a1_value="your_a1_cookie_value",
+                params={"num": "30", "cursor": "", "user_id": "123"}
+            )
+            
+            # POST请求签名  
+            signature = client.sign_xs_post(
+                uri="/api/sns/web/v1/login",
+                a1_value="your_a1_cookie_value", 
+                payload={"username": "test", "password": "123456"}
+            )
+            ```
+
   pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    needs: github-release
     # Environment and permissions trusted publishing.
     environment:
       # Create this environment in the GitHub repository under Settings -> Environments
@@ -34,5 +83,17 @@ jobs:
           TARBALL_FILE=$(find dist -name "*.tar.gz" -type f)
           uv run --isolated --no-project -p 3.12 --with "$TARBALL_FILE" -- python -c "from xhshow import Xhshow, CryptoProcessor; client = Xhshow(); print('Source distribution works'); print('Xhshow module:', client.__class__.__module__)"
       
+      - name: Check if version exists on PyPI
+        run: |
+          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          if pip index versions xhshow | grep -q "$VERSION"; then
+            echo "Version $VERSION already exists on PyPI, skipping upload"
+            echo "SKIP_PYPI=true" >> $GITHUB_ENV
+          else
+            echo "Version $VERSION not found on PyPI, proceeding with upload"
+            echo "SKIP_PYPI=false" >> $GITHUB_ENV
+          fi
+      
       - name: Publish to PyPI
+        if: env.SKIP_PYPI == 'false'
         run: uv publish --trusted-publishing always


### PR DESCRIPTION
## Sourcery 总结

添加自动化 GitHub Release 创建，并增强 PyPI 发布工作流，使其依赖于此并跳过已存在的版本。

新功能：
- 添加一个 GitHub Actions 作业，用于创建包含模板化的变更日志和使用说明的 GitHub Release。

CI：
- 要求 PyPI 发布作业等待 GitHub Release 作业完成。
- 检查发布版本是否已存在于 PyPI 上，如果存在则跳过上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automated GitHub Release creation and enhance the PyPI publishing workflow to depend on it and skip existing versions.

New Features:
- Add a GitHub Actions job to create a GitHub Release with a templated changelog and usage instructions.

CI:
- Require the PyPI publish job to wait for the GitHub Release job to finish.
- Check if the release version already exists on PyPI and skip the upload if it does.

</details>