### PR TITLE
refactor(config): 使用 dataclass 重构配置使其可自定义

### DIFF
--- a/src/xhshow/__init__.py
+++ b/src/xhshow/__init__.py
@@ -1,6 +1,5 @@
 import sys
 
-# Python version compatibility check
 if sys.version_info < (3, 10):
     print(
         f"Error: xhshow requires Python 3.10 or higher. "
@@ -12,7 +11,8 @@ if sys.version_info < (3, 10):
     sys.exit(1)
 
 from .client import Xhshow
+from .config import CryptoConfig
 from .core.crypto import CryptoProcessor
 
 __version__ = "0.1.0"
-__all__ = ["CryptoProcessor", "Xhshow"]
+__all__ = ["CryptoConfig", "CryptoProcessor", "Xhshow"]

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 from typing import Any, Literal
 
+from .config import CryptoConfig
 from .core.crypto import CryptoProcessor
 from .utils.validators import (
     validate_get_signature_params,
@@ -15,8 +16,9 @@ __all__ = ["Xhshow"]
 class Xhshow:
     """小红书请求客户端封装"""
 
-    def __init__(self):
-        self.crypto_processor = CryptoProcessor()
+    def __init__(self, config: CryptoConfig | None = None):
+        self.config = config or CryptoConfig()
+        self.crypto_processor = CryptoProcessor(self.config)
 
     def _build_content_string(
         self, method: str, uri: str, payload: dict[str, Any] | None = None

--- a/src/xhshow/config/config.py
+++ b/src/xhshow/config/config.py
@@ -1,6 +1,9 @@
+from dataclasses import dataclass
+
 __all__ = ["CryptoConfig"]
 
 
+@dataclass(frozen=True)
 class CryptoConfig:
     """加密处理相关配置常量"""
 

--- a/src/xhshow/core/crypto.py
+++ b/src/xhshow/core/crypto.py
@@ -10,12 +10,12 @@ __all__ = ["CryptoProcessor"]
 
 
 class CryptoProcessor:
-    def __init__(self):
-        self.config = CryptoConfig()
-        self.bit_ops = BitOperations()
-        self.b58encoder = Base58Encoder()
-        self.b64encoder = Base64Encoder()
-        self.hex_processor = HexProcessor()
+    def __init__(self, config: CryptoConfig | None = None):
+        self.config = config or CryptoConfig()
+        self.bit_ops = BitOperations(self.config)
+        self.b58encoder = Base58Encoder(self.config)
+        self.b64encoder = Base64Encoder(self.config)
+        self.hex_processor = HexProcessor(self.config)
         self.random_gen = RandomGenerator()
 
     def _encode_timestamp(self, ts: int, randomize_first: bool = True) -> list[int]:

--- a/src/xhshow/utils/bit_ops.py
+++ b/src/xhshow/utils/bit_ops.py
@@ -8,8 +8,8 @@ __all__ = ["BitOperations"]
 class BitOperations:
     """位操作和种子变换工具类"""
 
-    def __init__(self):
-        self.config = CryptoConfig()
+    def __init__(self, config: CryptoConfig):
+        self.config = config
 
     def normalize_to_32bit(self, value: int) -> int:
         """

--- a/src/xhshow/utils/encoder.py
+++ b/src/xhshow/utils/encoder.py
@@ -10,8 +10,8 @@ __all__ = ["Base58Encoder"]
 class Base58Encoder:
     """Base58编码器"""
 
-    def __init__(self):
-        self.config = CryptoConfig()
+    def __init__(self, config: CryptoConfig):
+        self.config = config
 
     def encode_to_b58(self, input_bytes: bytes | bytearray) -> str:
         """
@@ -59,8 +59,8 @@ class Base58Encoder:
 
 
 class Base64Encoder:
-    def __init__(self):
-        self.config = CryptoConfig()
+    def __init__(self, config: CryptoConfig):
+        self.config = config
 
     def encode_to_b64(self, data_to_encode: str) -> str:
         """

--- a/src/xhshow/utils/hex_utils.py
+++ b/src/xhshow/utils/hex_utils.py
@@ -8,8 +8,8 @@ __all__ = ["HexProcessor"]
 class HexProcessor:
     """十六进制数据处理工具类"""
 
-    def __init__(self):
-        self.config = CryptoConfig()
+    def __init__(self, config: CryptoConfig):
+        self.config = config
 
     def hex_string_to_bytes(self, hex_string: str) -> list[int]:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -247,7 +247,6 @@ wheels = [
 
 [[package]]
 name = "xhshow"
-version = "0.1.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #48

## Sourcery 摘要

重构 CryptoConfig 使其成为一个冻结的 dataclass，并通过加密工具传播它，以实现自定义配置

增强功能：
- 将 CryptoConfig 转换为一个冻结的 dataclass，以实现不可变性和自定义
- 允许 CryptoProcessor 及其子编码器 (Base58, Base64, BitOperations, HexProcessor) 接受并使用外部的 CryptoConfig 实例
- 更新 Xhshow 客户端以接受一个可选的 CryptoConfig，并将其传递给 CryptoProcessor
- 在包的公共 API 中公开 CryptoConfig，并相应地更新 __all__

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor CryptoConfig to be a frozen dataclass and propagate it through crypto utilities to enable custom configuration

Enhancements:
- Convert CryptoConfig into a frozen dataclass for immutability and customization
- Allow CryptoProcessor and its sub-encoders (Base58, Base64, BitOperations, HexProcessor) to accept and use an external CryptoConfig instance
- Update Xhshow client to accept an optional CryptoConfig and pass it to the CryptoProcessor
- Expose CryptoConfig in the package’s public API and update __all__ accordingly

</details>