### PR TITLE
fix(client): encode non-ASCII characters in GET params while preservi…

### DIFF
--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -50,13 +50,13 @@ class Xhshow:
                 params = []
                 for key, value in payload.items():
                     if isinstance(value, list | tuple):
-                        value_str = ','.join(str(v) for v in value)
+                        value_str = ",".join(str(v) for v in value)
                     elif value is not None:
                         value_str = str(value)
                     else:
-                        value_str = ''
+                        value_str = ""
 
-                    encoded_value = urllib.parse.quote(value_str, safe=',')
+                    encoded_value = urllib.parse.quote(value_str, safe=",")
                     params.append(f"{key}={encoded_value}")
 
                 return f"{uri}?{'&'.join(params)}"


### PR DESCRIPTION
Fixes #84

## Summary by Sourcery

错误修复：
- 修复错误的 GET 负载编码方式：现在对参数值进行 URL 编码，而不是仅替换字符 `'='`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect GET payload encoding by applying URL encoding to parameter values instead of only replacing '=' characters.

</details>