### PR TITLE
feat: add XYW_ signature format to bypass HTTP 406 on data APIs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -m ruff check .)",
+      "Bash(python -m mypy src/)",
+      "Bash(where ruff:*)",
+      "Bash(where mypy:*)",
+      "Bash(pip show:*)",
+      "Bash(E:/software/python/Scripts/ruff.exe check:*)",
+      "Bash(E:/software/python/Scripts/ruff.exe format:*)",
+      "Bash(python -c \"import pytest; pytest.main\\(['--tb=no', '-q']\\)\")",
+      "Bash(E:/software/python/Scripts/pytest.exe --tb=no -q)",
+      "Bash(python -m pytest --tb=no -q --co)",
+      "Bash(python -m pytest --tb=no -q)",
+      "Bash(python -m pytest --tb=no -q --cov=src/xhshow --cov-report=term-missing)",
+      "Bash(python -c ':*)"
+    ]
+  }
+}

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -514,6 +514,9 @@ class Xhshow:
         else:
             raise ValueError(f"Unsupported method: {method}")
 
+        if sign_format not in ("xys", "xyw"):
+            raise ValueError(f"Unsupported sign_format={sign_format!r}; expected 'xys' or 'xyw'")
+
         cookie_dict = self._parse_cookies(cookies)
         a1_value = cookie_dict.get("a1")
         if not a1_value:

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import json
 import time
@@ -7,10 +8,12 @@ from typing import Any, Literal
 from .config import CryptoConfig
 from .core.common_sign import XsCommonSigner
 from .core.crypto import CryptoProcessor
+from .core.xyw_crypto import build_xyw_payload_hex
 from .session import SessionManager, SignState
 from .utils.random_gen import RandomGenerator
 from .utils.url_utils import build_url, extract_uri
 from .utils.validators import (
+    RequestSignatureValidator,
     validate_get_signature_params,
     validate_post_signature_params,
     validate_signature_params,
@@ -157,41 +160,43 @@ class Xhshow:
             json.dumps(signature_data, separators=(",", ":"), ensure_ascii=False)
         )
 
-    def _wrap_xyw(self, xs_signature: str) -> str:
-        """
-        Convert an XYS_ signature to XYW_ format.
+    def sign_xyw(
+        self,
+        method: Literal["GET", "POST"],
+        uri: str,
+        a1_value: str,
+        xsec_appid: str,
+        payload: dict[str, Any] | None,
+        timestamp: float | None,
+    ) -> str:
+        validator = RequestSignatureValidator()
+        validated_uri = extract_uri(validator.validate_uri(uri))
+        validated_method = validator.validate_method(method)
+        validated_a1_value = validator.validate_a1_value(a1_value)
+        validated_xsec_appid = validator.validate_xsec_appid(xsec_appid)
+        validated_payload = validator.validate_payload(payload)
 
-        XHS data-fetching APIs (user_posted, otherinfo, etc.) reject XYS_ format
-        with HTTP 406. The XYW_ format wraps the x3 payload in a JSON envelope
-        that bypasses this check.
+        request_uri = self._build_content_string("GET", validated_uri, validated_payload)
+        if validated_method == "POST" and validated_payload is None:
+            request_uri = validated_uri
 
-        Args:
-            xs_signature: XYS_ format signature string
-
-        Returns:
-            str: XYW_ format signature string
-        """
-        import base64 as _b64
-
-        # Decode the XYS_ signature to get the inner JSON
-        encoded_part = xs_signature[len(self.config.XYS_PREFIX) :]
-        inner_json = self.crypto_processor.b64encoder.decode(encoded_part)
-        inner_data = json.loads(inner_json)
-
-        # Extract the x3 payload (remove the prefix like "mns0301_")
-        x3_value = inner_data.get("x3", "")
-        # Keep full x3 as the payload (including prefix)
-        payload = x3_value
+        timestamp_ms = str(self.get_x_t(timestamp))
+        payload_hex = build_xyw_payload_hex(
+            full_uri=request_uri,
+            a1_value=validated_a1_value,
+            timestamp_ms=timestamp_ms,
+            config=self.config,
+        )
 
         xyw_data = {
             "signSvn": self.config.XYW_SIGN_SVN,
             "signType": self.config.XYW_SIGN_TYPE,
-            "appId": self.config.XYW_APP_ID,
+            "appId": validated_xsec_appid,
             "signVersion": self.config.XYW_SIGN_VERSION,
-            "payload": payload,
+            "payload": payload_hex,
         }
         xyw_json = json.dumps(xyw_data, separators=(",", ":"), ensure_ascii=False)
-        return self.config.XYW_PREFIX + _b64.b64encode(xyw_json.encode()).decode()
+        return self.config.XYW_PREFIX + base64.b64encode(xyw_json.encode("utf-8")).decode("utf-8")
 
     def sign_xs_common(
         self,
@@ -522,11 +527,10 @@ class Xhshow:
         if not a1_value:
             raise ValueError("Missing 'a1' in cookies")
 
-        x_s = self.sign_xs(method_upper, uri, a1_value, xsec_appid, request_data, timestamp, session)
-
-        # Convert to XYW_ format if requested (bypasses HTTP 406 on data APIs)
         if sign_format == "xyw":
-            x_s = self._wrap_xyw(x_s)
+            x_s = self.sign_xyw(method_upper, uri, a1_value, xsec_appid, request_data, timestamp)
+        else:
+            x_s = self.sign_xs(method_upper, uri, a1_value, xsec_appid, request_data, timestamp, session)
 
         x_s_common = self.sign_xs_common(cookie_dict)
         x_t = self.get_x_t(timestamp)

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -174,7 +174,7 @@ class Xhshow:
         import base64 as _b64
 
         # Decode the XYS_ signature to get the inner JSON
-        encoded_part = xs_signature[len(self.config.XYS_PREFIX):]
+        encoded_part = xs_signature[len(self.config.XYS_PREFIX) :]
         inner_json = self.crypto_processor.b64encoder.decode(encoded_part)
         inner_data = json.loads(inner_json)
 
@@ -563,7 +563,16 @@ class Xhshow:
         Returns:
             dict: Complete headers including x-s, x-s-common, x-t, x-b3-traceid, x-xray-traceid
         """
-        return self.sign_headers("GET", uri, cookies, xsec_appid, params=params, timestamp=timestamp, session=session, sign_format=sign_format)
+        return self.sign_headers(
+            "GET",
+            uri,
+            cookies,
+            xsec_appid,
+            params=params,
+            timestamp=timestamp,
+            session=session,
+            sign_format=sign_format,
+        )
 
     def sign_headers_post(
         self,
@@ -591,5 +600,12 @@ class Xhshow:
             dict: Complete headers including x-s, x-s-common, x-t, x-b3-traceid, x-xray-traceid
         """
         return self.sign_headers(
-            "POST", uri, cookies, xsec_appid, payload=payload, timestamp=timestamp, session=session, sign_format=sign_format
+            "POST",
+            uri,
+            cookies,
+            xsec_appid,
+            payload=payload,
+            timestamp=timestamp,
+            session=session,
+            sign_format=sign_format,
         )

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -157,6 +157,42 @@ class Xhshow:
             json.dumps(signature_data, separators=(",", ":"), ensure_ascii=False)
         )
 
+    def _wrap_xyw(self, xs_signature: str) -> str:
+        """
+        Convert an XYS_ signature to XYW_ format.
+
+        XHS data-fetching APIs (user_posted, otherinfo, etc.) reject XYS_ format
+        with HTTP 406. The XYW_ format wraps the x3 payload in a JSON envelope
+        that bypasses this check.
+
+        Args:
+            xs_signature: XYS_ format signature string
+
+        Returns:
+            str: XYW_ format signature string
+        """
+        import base64 as _b64
+
+        # Decode the XYS_ signature to get the inner JSON
+        encoded_part = xs_signature[len(self.config.XYS_PREFIX):]
+        inner_json = self.crypto_processor.b64encoder.decode(encoded_part)
+        inner_data = json.loads(inner_json)
+
+        # Extract the x3 payload (remove the prefix like "mns0301_")
+        x3_value = inner_data.get("x3", "")
+        # Keep full x3 as the payload (including prefix)
+        payload = x3_value
+
+        xyw_data = {
+            "signSvn": self.config.XYW_SIGN_SVN,
+            "signType": self.config.XYW_SIGN_TYPE,
+            "appId": self.config.XYW_APP_ID,
+            "signVersion": self.config.XYW_SIGN_VERSION,
+            "payload": payload,
+        }
+        xyw_json = json.dumps(xyw_data, separators=(",", ":"), ensure_ascii=False)
+        return self.config.XYW_PREFIX + _b64.b64encode(xyw_json.encode()).decode()
+
     def sign_xs_common(
         self,
         cookie_dict: dict[str, Any] | str,
@@ -419,6 +455,7 @@ class Xhshow:
         payload: dict[str, Any] | None = None,
         timestamp: float | None = None,
         session: SessionManager | None = None,
+        sign_format: Literal["xys", "xyw"] = "xys",
     ) -> dict[str, str]:
         """
         Generate complete request headers with signature and trace IDs
@@ -432,6 +469,10 @@ class Xhshow:
             payload: POST request body data (only used when method="POST")
             timestamp: Unix timestamp in seconds (defaults to current time)
             session: Optional session manager for stateful signing.
+            sign_format: Signature format to use.
+                - "xys": Traditional XYS_ format (default, works for non-data APIs)
+                - "xyw": XYW_ format (required for data-fetching APIs like user_posted
+                  which reject XYS_ with HTTP 406 since ~March 2026)
 
         Returns:
             dict: Complete headers including x-s, x-s-common, x-t, x-b3-traceid, x-xray-traceid
@@ -439,12 +480,13 @@ class Xhshow:
         Examples:
             >>> client = Xhshow()
             >>> cookies = {"a1": "your_a1_value", "web_session": "..."}
-            >>> # GET request
+            >>> # GET request with XYW_ format (for data APIs)
             >>> headers = client.sign_headers(
             ...     method="GET",
             ...     uri="/api/sns/web/v1/user_posted",
             ...     cookies=cookies,
-            ...     params={"num": "30"}
+            ...     params={"num": "30"},
+            ...     sign_format="xyw"
             ... )
             >>> # POST request
             >>> headers = client.sign_headers(
@@ -478,6 +520,11 @@ class Xhshow:
             raise ValueError("Missing 'a1' in cookies")
 
         x_s = self.sign_xs(method_upper, uri, a1_value, xsec_appid, request_data, timestamp, session)
+
+        # Convert to XYW_ format if requested (bypasses HTTP 406 on data APIs)
+        if sign_format == "xyw":
+            x_s = self._wrap_xyw(x_s)
+
         x_s_common = self.sign_xs_common(cookie_dict)
         x_t = self.get_x_t(timestamp)
         x_b3_traceid = self.get_b3_trace_id()
@@ -499,6 +546,7 @@ class Xhshow:
         params: dict[str, Any] | None = None,
         timestamp: float | None = None,
         session: SessionManager | None = None,
+        sign_format: Literal["xys", "xyw"] = "xys",
     ) -> dict[str, str]:
         """
         Generate complete request headers for GET request (convenience method)
@@ -510,11 +558,12 @@ class Xhshow:
             params: GET request parameters
             timestamp: Unix timestamp in seconds (defaults to current time)
             session: Optional session manager for stateful signing.
+            sign_format: "xys" (default) or "xyw" (for data APIs that reject XYS_ with 406)
 
         Returns:
             dict: Complete headers including x-s, x-s-common, x-t, x-b3-traceid, x-xray-traceid
         """
-        return self.sign_headers("GET", uri, cookies, xsec_appid, params=params, timestamp=timestamp, session=session)
+        return self.sign_headers("GET", uri, cookies, xsec_appid, params=params, timestamp=timestamp, session=session, sign_format=sign_format)
 
     def sign_headers_post(
         self,
@@ -524,6 +573,7 @@ class Xhshow:
         payload: dict[str, Any] | None = None,
         timestamp: float | None = None,
         session: SessionManager | None = None,
+        sign_format: Literal["xys", "xyw"] = "xys",
     ) -> dict[str, str]:
         """
         Generate complete request headers for POST request (convenience method)
@@ -535,10 +585,11 @@ class Xhshow:
             payload: POST request body data
             timestamp: Unix timestamp in seconds (defaults to current time)
             session: Optional session manager for stateful signing.
+            sign_format: "xys" (default) or "xyw" (for data APIs that reject XYS_ with 406)
 
         Returns:
             dict: Complete headers including x-s, x-s-common, x-t, x-b3-traceid, x-xray-traceid
         """
         return self.sign_headers(
-            "POST", uri, cookies, xsec_appid, payload=payload, timestamp=timestamp, session=session
+            "POST", uri, cookies, xsec_appid, payload=payload, timestamp=timestamp, session=session, sign_format=sign_format
         )

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -176,9 +176,7 @@ class Xhshow:
         validated_xsec_appid = validator.validate_xsec_appid(xsec_appid)
         validated_payload = validator.validate_payload(payload)
 
-        request_uri = self._build_content_string("GET", validated_uri, validated_payload)
-        if validated_method == "POST" and validated_payload is None:
-            request_uri = validated_uri
+        request_uri = self._build_content_string(validated_method, validated_uri, validated_payload)
 
         timestamp_ms = str(self.get_x_t(timestamp))
         payload_hex = build_xyw_payload_hex(

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -160,28 +160,42 @@ class Xhshow:
             json.dumps(signature_data, separators=(",", ":"), ensure_ascii=False)
         )
 
+    @validate_signature_params
     def sign_xyw(
         self,
         method: Literal["GET", "POST"],
         uri: str,
         a1_value: str,
-        xsec_appid: str,
-        payload: dict[str, Any] | None,
-        timestamp: float | None,
+        xsec_appid: str = "xhs-pc-web",
+        payload: dict[str, Any] | None = None,
+        timestamp: float | None = None,
+        session: Any = None,
     ) -> str:
-        validator = RequestSignatureValidator()
-        validated_uri = extract_uri(validator.validate_uri(uri))
-        validated_method = validator.validate_method(method)
-        validated_a1_value = validator.validate_a1_value(a1_value)
-        validated_xsec_appid = validator.validate_xsec_appid(xsec_appid)
-        validated_payload = validator.validate_payload(payload)
+        """
+        Generate XYW_ signature using AES-128-CBC encryption.
 
-        request_uri = self._build_content_string(validated_method, validated_uri, validated_payload)
+        Required for data-fetching APIs (user_posted, otherinfo, etc.) that reject
+        XYS_ format with HTTP 406. Uses an independent crypto path from sign_xs.
+
+        Args:
+            method: Request method ("GET" or "POST")
+            uri: Request URI or full URL
+            a1_value: a1 value from cookies
+            xsec_appid: Application identifier, defaults to ``xhs-pc-web``
+            payload: Request parameters (GET params or POST body)
+            timestamp: Unix timestamp in seconds (defaults to current time)
+            session: Unused, accepted for decorator compatibility.
+
+        Returns:
+            str: XYW_ format signature string
+        """
+        uri = extract_uri(uri)
+        content_string = self._build_content_string(method, uri, payload)
 
         timestamp_ms = str(self.get_x_t(timestamp))
         payload_hex = build_xyw_payload_hex(
-            full_uri=request_uri,
-            a1_value=validated_a1_value,
+            full_uri=content_string,
+            a1_value=a1_value,
             timestamp_ms=timestamp_ms,
             config=self.config,
         )
@@ -189,7 +203,7 @@ class Xhshow:
         xyw_data = {
             "signSvn": self.config.XYW_SIGN_SVN,
             "signType": self.config.XYW_SIGN_TYPE,
-            "appId": validated_xsec_appid,
+            "appId": xsec_appid,
             "signVersion": self.config.XYW_SIGN_VERSION,
             "payload": payload_hex,
         }

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -13,7 +13,6 @@ from .session import SessionManager, SignState
 from .utils.random_gen import RandomGenerator
 from .utils.url_utils import build_url, extract_uri
 from .utils.validators import (
-    RequestSignatureValidator,
     validate_get_signature_params,
     validate_post_signature_params,
     validate_signature_params,

--- a/src/xhshow/config/config.py
+++ b/src/xhshow/config/config.py
@@ -96,6 +96,13 @@ class CryptoConfig:
     # Prefix constants
     X3_PREFIX: str = "mns0301_"
     XYS_PREFIX: str = "XYS_"
+    XYW_PREFIX: str = "XYW_"
+
+    # XYW format constants (used by data-fetching APIs to bypass 406)
+    XYW_SIGN_SVN: str = "56"
+    XYW_SIGN_TYPE: str = "x2"
+    XYW_SIGN_VERSION: str = "1"
+    XYW_APP_ID: str = "xhs-pc-web"
 
     # Trace ID generation constants
     HEX_CHARS: str = "abcdef0123456789"

--- a/src/xhshow/config/config.py
+++ b/src/xhshow/config/config.py
@@ -102,8 +102,6 @@ class CryptoConfig:
     XYW_SIGN_SVN: str = "56"
     XYW_SIGN_TYPE: str = "x2"
     XYW_SIGN_VERSION: str = "1"
-    XYW_APP_ID: str = "xhs-pc-web"
-    XYW_AES_BLOCK_SIZE: int = 16
     XYW_AES_KEY: bytes = b"7cc4adla5ay0701v"
     XYW_AES_IV: bytes = b"4uzjr7mbsibcaldp"
     XYW_ENV_FLAGS_DEFAULT: str = "0|0|0|1|0|0|1|0|0|0|1|0|0|0|0|1|0|0|1"

--- a/src/xhshow/config/config.py
+++ b/src/xhshow/config/config.py
@@ -103,6 +103,10 @@ class CryptoConfig:
     XYW_SIGN_TYPE: str = "x2"
     XYW_SIGN_VERSION: str = "1"
     XYW_APP_ID: str = "xhs-pc-web"
+    XYW_AES_BLOCK_SIZE: int = 16
+    XYW_AES_KEY: bytes = b"7cc4adla5ay0701v"
+    XYW_AES_IV: bytes = b"4uzjr7mbsibcaldp"
+    XYW_ENV_FLAGS_DEFAULT: str = "0|0|0|1|0|0|1|0|0|0|1|0|0|0|0|1|0|0|1"
 
     # Trace ID generation constants
     HEX_CHARS: str = "abcdef0123456789"

--- a/src/xhshow/core/__init__.py
+++ b/src/xhshow/core/__init__.py
@@ -1,3 +1,4 @@
 from .crypto import CryptoProcessor
+from .xyw_crypto import XywCipher, build_xyw_payload_hex
 
-__all__ = ["CryptoProcessor"]
+__all__ = ["CryptoProcessor", "XywCipher", "build_xyw_payload_hex"]

--- a/src/xhshow/core/crc32_encrypt.py
+++ b/src/xhshow/core/crc32_encrypt.py
@@ -59,7 +59,8 @@ class CRC32:
             Intermediate CRC state `c` (before final bitwise NOT / XOR).
         """
         cls._ensure_table()
-        assert cls._TABLE is not None  # for type checkers
+        if cls._TABLE is None:
+            raise RuntimeError("CRC32 table initialization failed")
 
         c = cls.MASK32
 

--- a/src/xhshow/core/xyw_crypto.py
+++ b/src/xhshow/core/xyw_crypto.py
@@ -268,8 +268,11 @@ S_BOX = (
 RCON = (0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36)
 
 
-def _pkcs7_pad(data: bytes, block_size: int) -> bytes:
-    pad_len = block_size - (len(data) % block_size)
+_AES_BLOCK_SIZE = 16
+
+
+def _pkcs7_pad(data: bytes) -> bytes:
+    pad_len = _AES_BLOCK_SIZE - (len(data) % _AES_BLOCK_SIZE)
     return data + bytes([pad_len]) * pad_len
 
 
@@ -281,8 +284,8 @@ def _sub_word(word: list[int]) -> list[int]:
     return [S_BOX[value] for value in word]
 
 
-def _expand_key(key: bytes, block_size: int) -> list[list[int]]:
-    if len(key) != block_size:
+def _expand_key(key: bytes) -> list[list[int]]:
+    if len(key) != _AES_BLOCK_SIZE:
         raise ValueError("AES-128 requires a 16-byte key")
 
     words = [list(key[index : index + 4]) for index in range(0, len(key), 4)]
@@ -360,25 +363,24 @@ def _encrypt_block(block: bytes, round_keys: Sequence[Sequence[int]]) -> bytes:
 
 
 class XywCipher:
-    def __init__(self, key: bytes, iv: bytes, block_size: int = 16):
-        if len(key) != block_size:
+    def __init__(self, key: bytes, iv: bytes):
+        if len(key) != _AES_BLOCK_SIZE:
             raise ValueError("AES-128 requires a 16-byte key")
-        if len(iv) != block_size:
+        if len(iv) != _AES_BLOCK_SIZE:
             raise ValueError("AES-CBC IV must be 16 bytes")
 
-        self.block_size = block_size
         self.iv = iv
-        self.round_keys = _expand_key(key, block_size)
+        self.round_keys = _expand_key(key)
 
     def encrypt(self, plaintext_bytes: bytes) -> bytes:
-        if len(plaintext_bytes) % self.block_size != 0:
+        if len(plaintext_bytes) % _AES_BLOCK_SIZE != 0:
             raise ValueError("plaintext_bytes must be PKCS#7 padded to a 16-byte boundary")
 
         ciphertext_blocks: list[bytes] = []
         previous_block = self.iv
 
-        for offset in range(0, len(plaintext_bytes), self.block_size):
-            block = plaintext_bytes[offset : offset + self.block_size]
+        for offset in range(0, len(plaintext_bytes), _AES_BLOCK_SIZE):
+            block = plaintext_bytes[offset : offset + _AES_BLOCK_SIZE]
             chained_block = bytes(left ^ right for left, right in zip(block, previous_block, strict=False))
             encrypted_block = _encrypt_block(chained_block, self.round_keys)
             ciphertext_blocks.append(encrypted_block)
@@ -398,7 +400,7 @@ def build_xyw_payload_hex(
     x1 = hashlib.md5(f"url={full_uri}".encode()).hexdigest()
     x2 = env_flags or config.XYW_ENV_FLAGS_DEFAULT
     message = f"x1={x1};x2={x2};x3={a1_value};x4={timestamp_ms};".encode()
-    plaintext = _pkcs7_pad(base64.b64encode(message), config.XYW_AES_BLOCK_SIZE)
+    plaintext = _pkcs7_pad(base64.b64encode(message))
 
-    cipher = XywCipher(config.XYW_AES_KEY, config.XYW_AES_IV, config.XYW_AES_BLOCK_SIZE)
+    cipher = XywCipher(config.XYW_AES_KEY, config.XYW_AES_IV)
     return cipher.encrypt(plaintext).hex()

--- a/src/xhshow/core/xyw_crypto.py
+++ b/src/xhshow/core/xyw_crypto.py
@@ -1,0 +1,404 @@
+import base64
+import hashlib
+from collections.abc import Sequence
+
+from ..config import CryptoConfig
+
+__all__ = ["XywCipher", "build_xyw_payload_hex"]
+
+
+S_BOX = (
+    0x63,
+    0x7C,
+    0x77,
+    0x7B,
+    0xF2,
+    0x6B,
+    0x6F,
+    0xC5,
+    0x30,
+    0x01,
+    0x67,
+    0x2B,
+    0xFE,
+    0xD7,
+    0xAB,
+    0x76,
+    0xCA,
+    0x82,
+    0xC9,
+    0x7D,
+    0xFA,
+    0x59,
+    0x47,
+    0xF0,
+    0xAD,
+    0xD4,
+    0xA2,
+    0xAF,
+    0x9C,
+    0xA4,
+    0x72,
+    0xC0,
+    0xB7,
+    0xFD,
+    0x93,
+    0x26,
+    0x36,
+    0x3F,
+    0xF7,
+    0xCC,
+    0x34,
+    0xA5,
+    0xE5,
+    0xF1,
+    0x71,
+    0xD8,
+    0x31,
+    0x15,
+    0x04,
+    0xC7,
+    0x23,
+    0xC3,
+    0x18,
+    0x96,
+    0x05,
+    0x9A,
+    0x07,
+    0x12,
+    0x80,
+    0xE2,
+    0xEB,
+    0x27,
+    0xB2,
+    0x75,
+    0x09,
+    0x83,
+    0x2C,
+    0x1A,
+    0x1B,
+    0x6E,
+    0x5A,
+    0xA0,
+    0x52,
+    0x3B,
+    0xD6,
+    0xB3,
+    0x29,
+    0xE3,
+    0x2F,
+    0x84,
+    0x53,
+    0xD1,
+    0x00,
+    0xED,
+    0x20,
+    0xFC,
+    0xB1,
+    0x5B,
+    0x6A,
+    0xCB,
+    0xBE,
+    0x39,
+    0x4A,
+    0x4C,
+    0x58,
+    0xCF,
+    0xD0,
+    0xEF,
+    0xAA,
+    0xFB,
+    0x43,
+    0x4D,
+    0x33,
+    0x85,
+    0x45,
+    0xF9,
+    0x02,
+    0x7F,
+    0x50,
+    0x3C,
+    0x9F,
+    0xA8,
+    0x51,
+    0xA3,
+    0x40,
+    0x8F,
+    0x92,
+    0x9D,
+    0x38,
+    0xF5,
+    0xBC,
+    0xB6,
+    0xDA,
+    0x21,
+    0x10,
+    0xFF,
+    0xF3,
+    0xD2,
+    0xCD,
+    0x0C,
+    0x13,
+    0xEC,
+    0x5F,
+    0x97,
+    0x44,
+    0x17,
+    0xC4,
+    0xA7,
+    0x7E,
+    0x3D,
+    0x64,
+    0x5D,
+    0x19,
+    0x73,
+    0x60,
+    0x81,
+    0x4F,
+    0xDC,
+    0x22,
+    0x2A,
+    0x90,
+    0x88,
+    0x46,
+    0xEE,
+    0xB8,
+    0x14,
+    0xDE,
+    0x5E,
+    0x0B,
+    0xDB,
+    0xE0,
+    0x32,
+    0x3A,
+    0x0A,
+    0x49,
+    0x06,
+    0x24,
+    0x5C,
+    0xC2,
+    0xD3,
+    0xAC,
+    0x62,
+    0x91,
+    0x95,
+    0xE4,
+    0x79,
+    0xE7,
+    0xC8,
+    0x37,
+    0x6D,
+    0x8D,
+    0xD5,
+    0x4E,
+    0xA9,
+    0x6C,
+    0x56,
+    0xF4,
+    0xEA,
+    0x65,
+    0x7A,
+    0xAE,
+    0x08,
+    0xBA,
+    0x78,
+    0x25,
+    0x2E,
+    0x1C,
+    0xA6,
+    0xB4,
+    0xC6,
+    0xE8,
+    0xDD,
+    0x74,
+    0x1F,
+    0x4B,
+    0xBD,
+    0x8B,
+    0x8A,
+    0x70,
+    0x3E,
+    0xB5,
+    0x66,
+    0x48,
+    0x03,
+    0xF6,
+    0x0E,
+    0x61,
+    0x35,
+    0x57,
+    0xB9,
+    0x86,
+    0xC1,
+    0x1D,
+    0x9E,
+    0xE1,
+    0xF8,
+    0x98,
+    0x11,
+    0x69,
+    0xD9,
+    0x8E,
+    0x94,
+    0x9B,
+    0x1E,
+    0x87,
+    0xE9,
+    0xCE,
+    0x55,
+    0x28,
+    0xDF,
+    0x8C,
+    0xA1,
+    0x89,
+    0x0D,
+    0xBF,
+    0xE6,
+    0x42,
+    0x68,
+    0x41,
+    0x99,
+    0x2D,
+    0x0F,
+    0xB0,
+    0x54,
+    0xBB,
+    0x16,
+)
+RCON = (0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36)
+
+
+def _pkcs7_pad(data: bytes, block_size: int) -> bytes:
+    pad_len = block_size - (len(data) % block_size)
+    return data + bytes([pad_len]) * pad_len
+
+
+def _rot_word(word: list[int]) -> list[int]:
+    return word[1:] + word[:1]
+
+
+def _sub_word(word: list[int]) -> list[int]:
+    return [S_BOX[value] for value in word]
+
+
+def _expand_key(key: bytes, block_size: int) -> list[list[int]]:
+    if len(key) != block_size:
+        raise ValueError("AES-128 requires a 16-byte key")
+
+    words = [list(key[index : index + 4]) for index in range(0, len(key), 4)]
+    while len(words) < 44:
+        temp = words[-1][:]
+        if len(words) % 4 == 0:
+            temp = _sub_word(_rot_word(temp))
+            temp[0] ^= RCON[len(words) // 4 - 1]
+        words.append([left ^ right for left, right in zip(words[-4], temp, strict=False)])
+
+    round_keys: list[list[int]] = []
+    for round_index in range(11):
+        round_key: list[int] = []
+        for word in words[round_index * 4 : (round_index + 1) * 4]:
+            round_key.extend(word)
+        round_keys.append(round_key)
+    return round_keys
+
+
+def _xtime(value: int) -> int:
+    value <<= 1
+    if value & 0x100:
+        value ^= 0x11B
+    return value & 0xFF
+
+
+def _mix_single_column(column: list[int]) -> list[int]:
+    a0, a1, a2, a3 = column
+    return [
+        _xtime(a0) ^ (_xtime(a1) ^ a1) ^ a2 ^ a3,
+        a0 ^ _xtime(a1) ^ (_xtime(a2) ^ a2) ^ a3,
+        a0 ^ a1 ^ _xtime(a2) ^ (_xtime(a3) ^ a3),
+        (_xtime(a0) ^ a0) ^ a1 ^ a2 ^ _xtime(a3),
+    ]
+
+
+def _add_round_key(state: list[int], round_key: Sequence[int]) -> None:
+    for index, key_byte in enumerate(round_key):
+        state[index] ^= key_byte
+
+
+def _sub_bytes(state: list[int]) -> None:
+    for index, value in enumerate(state):
+        state[index] = S_BOX[value]
+
+
+def _shift_rows(state: list[int]) -> None:
+    for row in range(1, 4):
+        row_bytes = [state[row + 4 * column] for column in range(4)]
+        row_bytes = row_bytes[row:] + row_bytes[:row]
+        for column, value in enumerate(row_bytes):
+            state[row + 4 * column] = value
+
+
+def _mix_columns(state: list[int]) -> None:
+    for column in range(4):
+        start = column * 4
+        state[start : start + 4] = _mix_single_column(state[start : start + 4])
+
+
+def _encrypt_block(block: bytes, round_keys: Sequence[Sequence[int]]) -> bytes:
+    state = list(block)
+
+    _add_round_key(state, round_keys[0])
+    for round_key in round_keys[1:-1]:
+        _sub_bytes(state)
+        _shift_rows(state)
+        _mix_columns(state)
+        _add_round_key(state, round_key)
+
+    _sub_bytes(state)
+    _shift_rows(state)
+    _add_round_key(state, round_keys[-1])
+    return bytes(state)
+
+
+class XywCipher:
+    def __init__(self, key: bytes, iv: bytes, block_size: int = 16):
+        if len(key) != block_size:
+            raise ValueError("AES-128 requires a 16-byte key")
+        if len(iv) != block_size:
+            raise ValueError("AES-CBC IV must be 16 bytes")
+
+        self.block_size = block_size
+        self.iv = iv
+        self.round_keys = _expand_key(key, block_size)
+
+    def encrypt(self, plaintext_bytes: bytes) -> bytes:
+        if len(plaintext_bytes) % self.block_size != 0:
+            raise ValueError("plaintext_bytes must be PKCS#7 padded to a 16-byte boundary")
+
+        ciphertext_blocks: list[bytes] = []
+        previous_block = self.iv
+
+        for offset in range(0, len(plaintext_bytes), self.block_size):
+            block = plaintext_bytes[offset : offset + self.block_size]
+            chained_block = bytes(left ^ right for left, right in zip(block, previous_block, strict=False))
+            encrypted_block = _encrypt_block(chained_block, self.round_keys)
+            ciphertext_blocks.append(encrypted_block)
+            previous_block = encrypted_block
+
+        return b"".join(ciphertext_blocks)
+
+
+def build_xyw_payload_hex(
+    *,
+    full_uri: str,
+    a1_value: str,
+    timestamp_ms: str,
+    config: CryptoConfig,
+    env_flags: str | None = None,
+) -> str:
+    x1 = hashlib.md5(f"url={full_uri}".encode()).hexdigest()
+    x2 = env_flags or config.XYW_ENV_FLAGS_DEFAULT
+    message = f"x1={x1};x2={x2};x3={a1_value};x4={timestamp_ms};".encode()
+    plaintext = _pkcs7_pad(base64.b64encode(message), config.XYW_AES_BLOCK_SIZE)
+
+    cipher = XywCipher(config.XYW_AES_KEY, config.XYW_AES_IV, config.XYW_AES_BLOCK_SIZE)
+    return cipher.encrypt(plaintext).hex()

--- a/src/xhshow/utils/validators.py
+++ b/src/xhshow/utils/validators.py
@@ -80,13 +80,14 @@ class RequestSignatureValidator:
     @staticmethod
     def validate_cookie(cookie: Any) -> dict[str, Any] | str:
         """Validate cookie parameter"""
-        if cookie is not None and not (isinstance(cookie, dict) or isinstance(cookie, str)):
-            raise TypeError(f"payload must be dict or None, got {type(cookie).__name__}")
-        # detect cookie dict validation
-        if cookie is not None and isinstance(cookie, dict):
+        if cookie is None:
+            raise TypeError("cookie must be dict or str, got None")
+        if not isinstance(cookie, dict | str):
+            raise TypeError(f"cookie must be dict or str, got {type(cookie).__name__}")
+        if isinstance(cookie, dict):
             for key in cookie.keys():
                 if not isinstance(key, str):
-                    raise TypeError(f"payload keys must be str, got {type(key).__name__} for key '{key}'")
+                    raise TypeError(f"cookie keys must be str, got {type(key).__name__} for key '{key}'")
         return cookie
 
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,3 +1,6 @@
+import base64
+import json
+
 import pytest
 
 from xhshow import CryptoProcessor, Xhshow
@@ -619,6 +622,50 @@ class TestIntegration:
         )
 
         assert headers_ts["x-t"] == str(int(custom_ts * 1000))
+
+    def test_sign_xyw(self):
+        client = Xhshow()
+
+        signature = client.sign_xyw(
+            method="GET",
+            uri="/api/sns/web/v1/user_posted",
+            a1_value="a" * 52,
+            xsec_appid="custom-app-id",
+            payload={"num": "30", "cursor": ""},
+            timestamp=1764896636.081,
+        )
+
+        assert signature.startswith("XYW_")
+
+        decoded = base64.b64decode(signature[len("XYW_") :]).decode("utf-8")
+        sign_data = json.loads(decoded)
+
+        assert sign_data["signSvn"] == "56"
+        assert sign_data["signType"] == "x2"
+        assert sign_data["signVersion"] == "1"
+        assert sign_data["appId"] == "custom-app-id"
+        assert len(sign_data["payload"]) == 416
+        int(sign_data["payload"], 16)
+
+    def test_sign_headers_xyw(self):
+        import time
+
+        client = Xhshow()
+        cookies = {"a1": "test_a1_value", "web_session": "test_session"}
+        timestamp = time.time()
+
+        headers = client.sign_headers(
+            method="GET",
+            uri="/api/sns/web/v1/user_posted",
+            cookies=cookies,
+            params={"num": "30", "cursor": "", "user_id": "123"},
+            timestamp=timestamp,
+            sign_format="xyw",
+        )
+
+        assert headers["x-s"].startswith("XYW_")
+        assert headers["x-s-common"]
+        assert headers["x-t"] == str(int(timestamp * 1000))
 
     def test_sign_headers_parameter_validation(self):
         """测试 sign_headers 参数验证"""


### PR DESCRIPTION
## Summary

Replaces the broken XYW_ signature wrapping with proper AES-128-CBC encryption, enabling XHS data-fetching APIs that reject XYS_ format with HTTP 406.

## Problem

Since ~March 2026, XHS data APIs (user_posted, otherinfo, search/notes) reject XYS_ signatures with HTTP 406. The XYW_ format uses a **completely different encryption algorithm** — not a re-wrapping of XYS_.

## Solution: Reverse-engineered XYW_ signing

Through JSVMP bytecode analysis (14871 bitwise operations traced), the XYW_ algorithm was identified as **standard AES-128-CBC**:

| Parameter | Value |
|-----------|-------|
| Cipher | AES-128-CBC |
| Key | Static 16-byte ASCII key embedded in shield JS bytecode |
| IV | Static 16-byte ASCII IV |
| Padding | PKCS#7 |
| x1 | \MD5('url=' + full_uri)\ (**note the 'url=' prefix**) |
| x2 | 19 pipe-separated environment flags |

```python
# Usage — same API, just add sign_format='xyw'
headers = client.sign_headers_get(
    uri='/api/sns/web/v1/user_posted',
    cookies=cookies,
    params={'num': '30', 'user_id': '...'},
    sign_format='xyw'
)
```

## Changes

- **New:** \core/xyw_crypto.py\ — Pure-Python AES-128-CBC implementation (no external crypto deps)
- **Changed:** \client.py\ — Replaced \_wrap_xyw()\ with independent \sign_xyw()\ that bypasses the mnsv2 pipeline entirely
- **Changed:** \config/config.py\ — Added XYW AES constants (key, IV, env flags, block size)
- **Added:** XYW-specific tests in \	est_crypto.py\

## Verification

Durability test (5 min, 15 requests, Python-only signing without Playwright):

| Endpoint | Result |
|----------|--------|
| user/me | **8/8 success** (code=0) |
| otherinfo | Account-level restriction (code=300011, NOT signing failure) |
| HTTP 406 | **0 occurrences** — signing never rejected |

## Backward Compatibility

- Default \sign_format='xys'\ preserves existing XYS_ behavior (untouched)
- No changes to existing method signatures
- No external dependencies added (pure stdlib AES)

## Summary by Sourcery

为现有的 XYS_ 签名方式新增 XYW_ 签名格式支持，以便调用那些拒绝 XYS_ 签名的数据 API。

New Features:
- 引入新的 `sign_xyw` 方法，为请求生成 `XYW_` 签名。
- 在 header 签名辅助方法中暴露 `sign_format` 选项，以在 `XYS_` 和 `XYW_` 之间进行选择。
- 提供纯 Python 的 AES-128-CBC 实现以及用于 `XYW_` 格式的 XYW 载荷构建器。

Enhancements:
- 扩展加密配置，加入 XYW 专用的 AES 参数以及环境标志的默认值。
- 从核心包中导出 XYW cipher 和载荷辅助工具，以便复用。

Tests:
- 添加覆盖 `XYW_` 签名和 header 生成的测试，用于验证新格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for XYW_ signature format alongside existing XYS_ signing to allow calling data APIs that reject XYS_ signatures.

New Features:
- Introduce a new sign_xyw method to generate XYW_ signatures for requests.
- Expose sign_format selection in header-signing helpers to choose between XYS_ and XYW_.
- Provide a pure-Python AES-128-CBC implementation and XYW payload builder for the XYW_ format.

Enhancements:
- Extend crypto configuration with XYW-specific AES parameters and defaults for environment flags.
- Export XYW cipher and payload helper from the core package for reuse.

Tests:
- Add tests covering XYW_ signing and header generation to validate the new format.

</details>