### PR TITLE
Update sdk version to 4.3.3, solve the 406 error of `user/otherinfo`, `user_posted`.

### DIFF
--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -96,7 +96,7 @@ class Xhshow:
             str: Base64 encoded signature
         """
         payload_array = self.crypto_processor.build_payload_array(
-            d_value, a1_value, xsec_appid, string_param, timestamp
+            d_value, d_value, a1_value, xsec_appid, string_param, timestamp
         )
 
         xor_result = self.crypto_processor.bit_ops.xor_transform_array(payload_array)
@@ -141,11 +141,12 @@ class Xhshow:
         uri = extract_uri(uri)
         content_string = self._build_content_string(method, uri, payload)
         d_value = self._generate_d_value(content_string)
+        m_value = d_value if method == "GET" else hashlib.md5(uri.encode("utf-8")).hexdigest()
 
         sign_state = session.get_current_state(content_string) if session else None
 
         payload_array = self.crypto_processor.build_payload_array(
-            d_value, a1_value, xsec_appid, content_string, timestamp, sign_state=sign_state
+            d_value, m_value, a1_value, xsec_appid, content_string, timestamp, sign_state=sign_state
         )
         xor_result = self.crypto_processor.bit_ops.xor_transform_array(payload_array)
         x3_signature = self.crypto_processor.b64encoder.encode_x3(xor_result[: self.config.PAYLOAD_LENGTH])

--- a/src/xhshow/client.py
+++ b/src/xhshow/client.py
@@ -142,7 +142,7 @@ class Xhshow:
         content_string = self._build_content_string(method, uri, payload)
         d_value = self._generate_d_value(content_string)
 
-        sign_state = session.get_current_state(uri) if session else None
+        sign_state = session.get_current_state(content_string) if session else None
 
         payload_array = self.crypto_processor.build_payload_array(
             d_value, a1_value, xsec_appid, content_string, timestamp, sign_state=sign_state

--- a/src/xhshow/config/config.py
+++ b/src/xhshow/config/config.py
@@ -13,8 +13,8 @@ class CryptoConfig:
     GID_URL = "https://as.xiaohongshu.com/api/sec/v1/shield/webprofile"
     DATA_PALTFORM = "Windows"
     DATA_SVN = "2"
-    DATA_SDK_VERSION = "4.2.6"
-    DATA_webBuild = "5.0.3"
+    DATA_SDK_VERSION = "4.3.3"
+    DATA_webBuild = "6.3.0"
 
     # Bitwise operation constants
     MAX_32BIT: int = 0xFFFFFFFF
@@ -113,7 +113,7 @@ class CryptoConfig:
             "s0": 5,
             "s1": "",
             "x0": "1",
-            "x1": "4.2.6",
+            "x1": "4.3.3",
             "x2": "Windows",
             "x3": "xhs-pc-web",
             "x4": "4.86.0",

--- a/src/xhshow/core/crypto.py
+++ b/src/xhshow/core/crypto.py
@@ -81,6 +81,7 @@ class CryptoProcessor:
     def build_payload_array(
         self,
         hex_parameter: str,
+        hex_md5_path: str,
         a1_value: str,
         app_identifier: str = "xhs-pc-web",
         string_param: str = "",
@@ -92,6 +93,7 @@ class CryptoProcessor:
 
         Args:
             hex_parameter (str): 32-character hexadecimal parameter (MD5 hash of uri+data)
+            hex_md5_path (str): 32-character hexadecimal parameter (MD5 hash of url+queryparams)
             a1_value (str): a1 value from cookies
             app_identifier (str): Application identifier, default "xhs-pc-web"
             string_param (str): String parameter (URI+data for MD5 and length calculation)
@@ -154,9 +156,7 @@ class CryptoProcessor:
         part11 += [self.config.ENV_TABLE[i] ^ self.config.ENV_CHECKS_DEFAULT[i] for i in range(1, 15)]
         payload.extend(part11)
 
-        string_param_bytes = string_param.encode("utf-8")
-        hex_md5 = hashlib.md5(string_param_bytes).hexdigest()
-        md5_path_bytes = [int(hex_md5[i : i + 2], 16) for i in range(0, 32, 2)]
+        md5_path_bytes = [int(hex_md5_path[i : i + 2], 16) for i in range(0, 32, 2)]
 
         payload.extend(self.config.A3_PREFIX + [b ^ seed_byte for b in self._custom_hash_v2(ts_bytes + md5_path_bytes)])
 

--- a/src/xhshow/core/crypto.py
+++ b/src/xhshow/core/crypto.py
@@ -8,7 +8,6 @@ from ..utils.bit_ops import BitOperations
 from ..utils.encoder import Base64Encoder
 from ..utils.hex_utils import HexProcessor
 from ..utils.random_gen import RandomGenerator
-# from ..utils.url_utils import extract_api_path
 
 if TYPE_CHECKING:
     from ..session import SignState

--- a/src/xhshow/core/crypto.py
+++ b/src/xhshow/core/crypto.py
@@ -155,9 +155,8 @@ class CryptoProcessor:
         part11 += [self.config.ENV_TABLE[i] ^ self.config.ENV_CHECKS_DEFAULT[i] for i in range(1, 15)]
         payload.extend(part11)
 
-        api_path = extract_api_path(string_param)
-        api_path_bytes = api_path.encode("utf-8")
-        hex_md5 = hashlib.md5(api_path_bytes).hexdigest()
+        string_param_bytes = string_param.encode("utf-8")
+        hex_md5 = hashlib.md5(string_param_bytes).hexdigest()
         md5_path_bytes = [int(hex_md5[i : i + 2], 16) for i in range(0, 32, 2)]
 
         payload.extend(self.config.A3_PREFIX + [b ^ seed_byte for b in self._custom_hash_v2(ts_bytes + md5_path_bytes)])

--- a/src/xhshow/core/crypto.py
+++ b/src/xhshow/core/crypto.py
@@ -8,7 +8,7 @@ from ..utils.bit_ops import BitOperations
 from ..utils.encoder import Base64Encoder
 from ..utils.hex_utils import HexProcessor
 from ..utils.random_gen import RandomGenerator
-from ..utils.url_utils import extract_api_path
+# from ..utils.url_utils import extract_api_path
 
 if TYPE_CHECKING:
     from ..session import SignState

--- a/src/xhshow/core/crypto.py
+++ b/src/xhshow/core/crypto.py
@@ -1,4 +1,3 @@
-import hashlib
 import struct
 import time
 from typing import TYPE_CHECKING

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -15,7 +15,7 @@ class TestCryptoProcessor:
         hex_param = "d41d8cd98f00b204e9800998ecf8427e"
         a1_value = "test_a1_value"
 
-        result = self.crypto.build_payload_array(hex_param, a1_value)
+        result = self.crypto.build_payload_array(hex_param, hex_param, a1_value)
 
         assert isinstance(result, list)
         assert len(result) > 50

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -112,7 +112,7 @@ def test_signing_with_session_post(mock_crypto_processor):
     assert actual_state.page_load_timestamp == session.page_load_timestamp
     assert actual_state.sequence_value == session.sequence_value
     assert actual_state.window_props_length == session.window_props_length
-    assert actual_state.uri_length == len(uri)
+    assert actual_state.uri_length >= len(uri)
 
 
 def test_signing_without_session_post(mock_crypto_processor):
@@ -216,7 +216,7 @@ def test_sign_xs_get_with_session(mock_crypto_processor):
     actual_state = kwargs.get("sign_state")
 
     assert actual_state is not None
-    assert actual_state.uri_length == len(uri)
+    assert actual_state.uri_length >= len(uri)
 
 
 def test_sign_xs_post_with_session(mock_crypto_processor):
@@ -239,4 +239,4 @@ def test_sign_xs_post_with_session(mock_crypto_processor):
     actual_state = kwargs.get("sign_state")
 
     assert actual_state is not None
-    assert actual_state.uri_length == len(uri)
+    assert actual_state.uri_length >= len(uri)


### PR DESCRIPTION
Update sdk version to 4.3.3, solve the 406 error of `user/otherinfo`, `user_posted`.

## Summary by Sourcery

更新与 SDK 相关的配置和签名逻辑，使其符合最新的 API 要求，并解决特定用户端点返回 406 的问题。

增强内容：
- 将已配置的 SDK 和 Web 构建版本分别提升至 4.3.3 和 6.3.0，以匹配当前平台。
- 调整加密负载哈希逻辑，从仅使用 API 路径改为使用完整的请求内容字符串。
- 更新签名状态查询方式，从以原始 URI 作为键改为以构建后的内容字符串作为键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update SDK-related configuration and signing logic to align with the latest API requirements and resolve 406 responses for specific user endpoints.

Enhancements:
- Bump configured SDK and web build versions to 4.3.3 and 6.3.0 to match the current platform.
- Adjust crypto payload hashing to use the full request content string instead of only the API path.
- Update signing state lookup to be keyed by the built content string rather than the raw URI.

</details>